### PR TITLE
Removing  `forEach` and using `map`  for better readability

### DIFF
--- a/conf/parallel.conf.js
+++ b/conf/parallel.conf.js
@@ -46,6 +46,8 @@ exports.config = {
 
 // Code to support common capabilities
 exports.config.capabilities.forEach(function(caps){
-  for(var i in exports.config.commonCapabilities) caps[i] = caps[i] || exports.config.commonCapabilities[i];
+  caps = caps.map(function(cap, idx) {
+    return cap || exports.config.commonCapabilities[idx];
+  });
 });
 


### PR DESCRIPTION
Using `forEach` in code is usually avoided because of the side-effects. 