### PR TITLE
Fix "element click intercepted" error in single_test.js

### DIFF
--- a/tests/specs/single_test.js
+++ b/tests/specs/single_test.js
@@ -2,7 +2,7 @@ describe('Google\'s Search Functionality', () => {
   it('can find search results', () => {
       browser.url('https://www.google.com/ncr');
       $('[name="q"]').setValue('BrowserStack');
-      $('[name="btnK"]').click();
+      browser.keys("\uE007");
       browser.getTitle().should.match(/BrowserStack - Google Search/i);
   });
 });


### PR DESCRIPTION
Google suggestion list overlaps the "Search" button hence click intercepts. As a workaround, the enter button is clicked here instead.