### PR TITLE
Update parallel.conf.js for rendering common caps

### DIFF
--- a/conf/parallel.conf.js
+++ b/conf/parallel.conf.js
@@ -46,7 +46,6 @@ exports.config = {
 
 // Code to support common capabilities
 exports.config.capabilities.forEach(function(caps){
-  for (var key in caps) { exports.config.commonCapabilities[key] = caps[key]; }
-  return exports.config.commonCapabilities
+  for(var i in exports.config.commonCapabilities) caps[i] = caps[i] || exports.config.commonCapabilities[i];
 });
 


### PR DESCRIPTION
Have updated the looping condition for fetching capability details based on the one specified on our documentation page which renders the caps mentioned correctly like name and build details.