### PR TITLE
fix: update 'hostname' in conf file

### DIFF
--- a/conf/base.conf.js
+++ b/conf/base.conf.js
@@ -20,7 +20,7 @@ exports.config = {
   waitforTimeout: 10000,
   connectionRetryTimeout: 90000,
   connectionRetryCount: 3,
-  host: 'hub.browserstack.com',
+  hostname: 'hub.browserstack.com',
   services: [['@browserstack/wdio-browserstack-service']],
 
   before: function () {


### PR DESCRIPTION
hostname is the correct key that needs to be used as per webdriverIO docs rather than host, host gets ignored.